### PR TITLE
Fix compiler errors in loader

### DIFF
--- a/Source/Atmosphere/stratosphere/loader/source/oc/Makefile
+++ b/Source/Atmosphere/stratosphere/loader/source/oc/Makefile
@@ -22,7 +22,7 @@ INC_DIRS := $(shell find $(SRC_DIRS) -type d)
 # Add a prefix to INC_DIRS. So moduleA would become -ImoduleA. GCC understands this -I flag
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
-CPPFLAGS := $(INC_FLAGS) -Wall -Werror -std=c++20 -Og -g
+CPPFLAGS := $(INC_FLAGS) -Wall -Werror -Wno-unused-result -std=c++20 -Og -g
 
 # The final build step.
 $(TARGET_EXEC): $(OBJS)

--- a/Source/Atmosphere/stratosphere/loader/source/oc/oc_test.cpp
+++ b/Source/Atmosphere/stratosphere/loader/source/oc/oc_test.cpp
@@ -84,7 +84,7 @@ Result Test_PcvDvfsTable() {
 
     constexpr size_t limit = ams::ldr::oc::pcv::DvfsTableEntryLimit;
     cvb_entry_t customized_table[limit] = {};
-    for (int i = 0; i < limit; i++) {
+    for (size_t i = 0; i < limit; i++) {
         assert(GetDvfsTableEntryCount(customized_table) == i);
         auto p = GetDvfsTableLastEntry(customized_table);
         if (p)
@@ -160,8 +160,8 @@ int main(int argc, char** argv) {
             ams::ldr::oc::pcv::erista::Patch(reinterpret_cast<uintptr_t>(erista_buf), file_size);
             if (save_patched) {
                 char* exec_path_erista = reinterpret_cast<char *>(malloc(exec_path_patched_len));
-                strlcpy(exec_path_erista, exec_path, exec_path_patched_len);
-                strlcat(exec_path_erista, erista_ext, exec_path_patched_len);
+                strncpy(exec_path_erista, exec_path, exec_path_patched_len);
+                strncat(exec_path_erista, erista_ext, exec_path_patched_len);
                 saveExec(exec_path_erista, erista_buf, file_size);
                 free(exec_path_erista);
             }
@@ -176,8 +176,8 @@ int main(int argc, char** argv) {
             ams::ldr::oc::pcv::mariko::Patch(reinterpret_cast<uintptr_t>(mariko_buf), file_size);
             if (save_patched) {
                 char* exec_path_mariko = reinterpret_cast<char *>(malloc(exec_path_patched_len));
-                strlcpy(exec_path_mariko, exec_path, exec_path_patched_len);
-                strlcat(exec_path_mariko, mariko_ext, exec_path_patched_len);
+                strncpy(exec_path_mariko, exec_path, exec_path_patched_len);
+                strncat(exec_path_mariko, mariko_ext, exec_path_patched_len);
                 saveExec(exec_path_mariko, mariko_buf, file_size);
                 free(exec_path_mariko);
             }
@@ -193,8 +193,8 @@ int main(int argc, char** argv) {
         ams::ldr::oc::ptm::Patch(reinterpret_cast<uintptr_t>(mariko_buf), file_size);
         if (save_patched) {
             char* exec_path_mariko = reinterpret_cast<char *>(malloc(exec_path_patched_len));
-            strlcpy(exec_path_mariko, exec_path, exec_path_patched_len);
-            strlcat(exec_path_mariko, mariko_ext, exec_path_patched_len);
+            strncpy(exec_path_mariko, exec_path, exec_path_patched_len);
+            strncat(exec_path_mariko, mariko_ext, exec_path_patched_len);
             saveExec(exec_path_mariko, mariko_buf, file_size);
             free(exec_path_mariko);
         }

--- a/Source/Atmosphere/stratosphere/loader/source/oc/oc_test.hpp
+++ b/Source/Atmosphere/stratosphere/loader/source/oc/oc_test.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #ifndef ATMOSPHERE_IS_STRATOSPHERE
+#include <cassert>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>


### PR DESCRIPTION
Dunno if this is because you still use GCC 12, but it's not possible to compile it with GCC 13 without those fixes.

`-Wno-unused-return` is used because otherwise `oc_test.cpp` throws error at `fread`.
`int i` is now `size_t` otherwise there are errors related to comparison of different signedness
unix `strlcpy` and `strlcat` were replaced with C standard `strncpy` and `strncat`

Dunno what this is used for, just somebody asked me why they can't compile it.